### PR TITLE
fix: crash when showing the calendar on the schedule screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@
 This README would normally document whatever steps are necessary to get the
 application up and running.
 
-Things you may want to cover:
+Things you may want to cover: Test
 
-* Ruby version
+- Ruby version
 
-* System dependencies
+- System dependencies
 
-* Configuration
+- Configuration
 
-* Database creation
+- Database creation
 
-* Database initialization
+- Database initialization
 
-* How to run the test suite
+- How to run the test suite
 
-* Services (job queues, cache servers, search engines, etc.)
+- Services (job queues, cache servers, search engines, etc.)
 
-* Deployment instructions
+- Deployment instructions
 
-* ...
+- ...


### PR DESCRIPTION
### Reference issues `(optional)`

- [Crash when showing the calendar on the schedule screen](https://github.com/monstar-lab-consulting/ozaka/issues/1)

### Descriptions `(required)`

- Fix the issue causing the app to crash when the user tries to open the calendar. The reason for the app crash is that a start date variable in the calendar library was null and was used during the initialization process

### Checklist `(required)`

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have tested the feature on most environments/devices/OSes and it has worked well

### Screenshots `(optional)`

- ![image](https://user-images.githubusercontent.com/40161877/228592375-37d21493-bfe6-410b-9790-47f4883aad8f.png)

### More related references `(optional)`

- [Solution to fix crash calendar on the stackoverflow](https://stackoverflow.com/questions)